### PR TITLE
fix(android): keep connected BLE devices with uncached service UUIDs

### DIFF
--- a/android/src/main/java/so/onekey/lib/ble/utils/BleUtilsModule.kt
+++ b/android/src/main/java/so/onekey/lib/ble/utils/BleUtilsModule.kt
@@ -192,14 +192,34 @@ class BleUtilsModule(private val reactContext: ReactApplicationContext) :
       return
     }
 
+    val wantedServiceUuids = HashSet<String>()
+    if (serviceUUIDs != null) {
+      for (i in 0 until serviceUUIDs.size()) {
+        serviceUUIDs.getString(i)?.let { wantedServiceUuids.add(it.lowercase()) }
+      }
+    }
+
     val peripherals: List<BluetoothDevice> =
       getBluetoothManager()?.getConnectedDevices(GATT) ?: emptyList()
     for (entry in peripherals) {
+      if (wantedServiceUuids.isNotEmpty() && !deviceExposesService(entry, wantedServiceUuids)) {
+        continue
+      }
       val peripheral = Peripheral(entry)
       val jsonBundle: WritableMap = peripheral.asWritableMap()
       map.pushMap(jsonBundle)
     }
     callback.invoke(null, map)
+  }
+
+  @SuppressLint("MissingPermission")
+  private fun deviceExposesService(
+    device: BluetoothDevice,
+    wantedServiceUuids: Set<String>
+  ): Boolean {
+    val uuids = device.uuids
+    if (uuids.isNullOrEmpty()) return true
+    return uuids.any { wantedServiceUuids.contains(it.uuid.toString().lowercase()) }
   }
 
   private class MyBroadcastReceiver(private val module: BleUtilsModule) : BroadcastReceiver() {

--- a/android/src/main/java/so/onekey/lib/ble/utils/data/Peripheral.kt
+++ b/android/src/main/java/so/onekey/lib/ble/utils/data/Peripheral.kt
@@ -26,6 +26,10 @@ class Peripheral(
       advertising.putBoolean("isConnectable", true)
 
       map.putMap("advertising", advertising)
+
+      val serviceUUIDs = Arguments.createArray()
+      device.uuids?.forEach { serviceUUIDs.pushString(it.uuid.toString()) }
+      map.putArray("serviceUUIDs", serviceUUIDs)
     } catch (e: Exception) { // this shouldn't happen
       Log.e("BleUtils", "Unexpected error on asWritableMap", e)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onekeyfe/react-native-ble-utils",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "ble uilts",
   "source": "./src/index.tsx",
   "main": "./dist/commonjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ class BleUtils {
 
   /**
    *
-   * @param serviceUUIDs [optional] not used on android, optional on ios.
+   * @param serviceUUIDs [optional] filter by service UUID (android + ios); empty = no filter.
    * @returns
    */
   getConnectedPeripherals(serviceUUIDs: string[] = []) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -33,6 +33,7 @@ export interface Peripheral {
   name?: string;
   advertising: AdvertisingData;
   bondState: BondState;
+  serviceUUIDs?: string[];
 }
 
 export interface BondState {


### PR DESCRIPTION
getConnectedPeripherals filters by serviceUUIDs but treats a null/empty device.uuids as unknown (keep), not absent (drop), so bonded OneKey devices whose GATT services aren't cached in getUuids() aren't lost on some ROMs. Also exposes serviceUUIDs on peripherals. Bump 0.1.6.